### PR TITLE
Avoid re-uploading teletyped SSH keys

### DIFF
--- a/tools/teletyped/helper.py
+++ b/tools/teletyped/helper.py
@@ -17,6 +17,7 @@ POLL_INTERVAL = 10
 CHECK_INTERVAL = 60
 KEY_PATH = "/persist/comma/id_ed25519_goranconnect.pub"
 KEY_PATH_PRIV = "/persist/comma/id_ed25519_goranconnect"
+KEY_SENT_FILE = f"{KEY_PATH}.sent"
 REALDATA_DIR = "/data/media/0/realdata"
 BOOT_DIR = os.path.join(REALDATA_DIR, "boot")
 REMOTE_USER = "ubuntu"

--- a/tools/teletyped/ssh_key.py
+++ b/tools/teletyped/ssh_key.py
@@ -6,7 +6,10 @@ import requests
 import sentry_sdk
 from datetime import datetime
 from common.params import Params
-from tools.teletyped.helper import log, get_dongle_id, get_api_token, KEY_PATH, KEY_PATH_PRIV
+from tools.teletyped.helper import (
+    log, get_dongle_id, get_api_token,
+    KEY_PATH, KEY_PATH_PRIV, KEY_SENT_FILE,
+)
 
 # === Configuration ===
 # KEY_PATH = "/persist/comma/id_ed25519_goranconnect.pub"
@@ -51,6 +54,14 @@ def send_ssh_key():
     device_id = get_dongle_id()
     ensure_ssh_key()
     public_key = read_public_key()
+    if os.path.exists(KEY_SENT_FILE):
+        try:
+            with open(KEY_SENT_FILE, "r") as f:
+                if f.read().strip() == public_key:
+                    log("[i] SSH key already uploaded, skipping send")
+                    return
+        except Exception:
+            pass
     payload = {
         "device_id": device_id,
         "public_key": public_key
@@ -65,6 +76,11 @@ def send_ssh_key():
             response = requests.post(API_URL_KEY, json=payload, headers=headers, timeout=TIMEOUT)
             response.raise_for_status()
             log(f"[✓] SSH key uploaded successfully for device {device_id}")
+            try:
+                with open(KEY_SENT_FILE, "w") as f:
+                    f.write(public_key)
+            except Exception as e:
+                log(f"[!] Failed to write key sent marker: {e}", level="ERROR")
             return
         except requests.RequestException as e:
             log(f"[!] Attempt {attempt} failed: {e}", level="ERROR")


### PR DESCRIPTION
## Summary
- share key upload marker path via `helper.py`
- use shared constant in `ssh_key.py`

## Testing
- `python3 -m py_compile tools/teletyped/ssh_key.py tools/teletyped/helper.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c5e047bc83229a7ac808ff541c09