### PR TITLE
Remove setup_resolv call from teletyped

### DIFF
--- a/tools/teletyped/teletyped.py
+++ b/tools/teletyped/teletyped.py
@@ -161,11 +161,6 @@ def main():
   if not device_id:
     return
 
-  # Run at startup
-  setup_script = os.path.join(base_dir, "setup_resolv.sh")
-  if not os.path.isfile(setup_script):
-    raise FileNotFoundError(f"setup_resolv.sh not found at {setup_script}")
-  subprocess.run(setup_script, check=True)
 
   # Check if goranconnect will respond
   check_server(API_URL)  # 👈 This blocks until server is ready


### PR DESCRIPTION
## Summary
- remove unused setup_resolv startup script call in `tools/teletyped/teletyped.py`

## Testing
- `pre-commit run --files tools/teletyped/teletyped.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575bef64608322a88a9eb552aaba6c