### PR TITLE
Add internet checks to teletyped scripts

### DIFF
--- a/tools/teletyped/announce_boot_routes.py
+++ b/tools/teletyped/announce_boot_routes.py
@@ -3,7 +3,15 @@ import json
 import requests
 from datetime import datetime
 import re
-from tools.teletyped.helper import get_dongle_id, get_api_token, log, API_URL, REALDATA_DIR, BOOT_DIR
+from tools.teletyped.helper import (
+  get_dongle_id,
+  get_api_token,
+  log,
+  API_URL,
+  REALDATA_DIR,
+  BOOT_DIR,
+  has_internet_connection,
+)
 
 # === Config ===
 TIMEOUT = 5
@@ -77,6 +85,9 @@ def main():
   try:
     # device_id = read_dongle_id()
     device_id = get_dongle_id()
+    if not has_internet_connection():
+      log("No internet connection. Exiting.", "WARN")
+      return 1
     existing_routes = get_existing_routes(device_id)
 
     boot_routes = list_boot_routes()

--- a/tools/teletyped/helper.py
+++ b/tools/teletyped/helper.py
@@ -5,11 +5,13 @@ import os
 try:
   # Newer style (e.g. `python -m openpilot.tools.teletyped.helper`)
   from openpilot.common.params import Params
-  from openpilot.system.hardware import PC
+  from openpilot.system.hardware import PC, HARDWARE
+  from cereal import log
 except ModuleNotFoundError:
   # Fallback for old-style in-tree execution
   from common.params import Params
-  from system.hardware import PC
+  from system.hardware import PC, HARDWARE
+  from cereal import log
 
 
 API_URL = "https://goranconnect.duckdns.org"
@@ -26,6 +28,15 @@ LOCAL_PORT = 22
 PIDFILE = "/tmp/reverse_ssh_tunnel.pid"
 WORMHOLE_BINARY = os.path.join(os.path.dirname(__file__), "wormhole-william")
 SENDER_LOG = os.path.join(os.path.dirname(__file__), "sender_log.json")
+
+NetworkType = log.DeviceState.NetworkType
+
+def has_internet_connection() -> bool:
+  """Check if the device currently has any network connectivity."""
+  try:
+    return HARDWARE.get_network_type() != NetworkType.none
+  except Exception:
+    return True
 
 class Paths:
   @staticmethod

--- a/tools/teletyped/route_sender.py
+++ b/tools/teletyped/route_sender.py
@@ -6,7 +6,18 @@ from zipfile import ZipFile, ZIP_DEFLATED, ZipInfo
 import subprocess
 import requests
 from datetime import datetime
-from tools.teletyped.helper import log, get_dongle_id, get_api_token, API_URL, WORMHOLE_BINARY, SENDER_LOG, CHECK_INTERVAL, REALDATA_DIR, BOOT_DIR
+from tools.teletyped.helper import (
+  log,
+  get_dongle_id,
+  get_api_token,
+  API_URL,
+  WORMHOLE_BINARY,
+  SENDER_LOG,
+  CHECK_INTERVAL,
+  REALDATA_DIR,
+  BOOT_DIR,
+  has_internet_connection,
+)
 
 API_TOKEN = get_api_token()
 TIMEOUT = 5
@@ -129,6 +140,10 @@ def send_file_wormhole(zip_path, device_id, route_name):
 
 
 def route_sender_step(device_id):
+  if not has_internet_connection():
+    log("No internet connection. Skipping route sender step.", "WARN")
+    return
+
   routes = get_requested_routes(device_id)
   log(f"🔄 Route sender tick - {len(routes)} requested route(s)")
 

--- a/tools/teletyped/teletyped.py
+++ b/tools/teletyped/teletyped.py
@@ -6,7 +6,20 @@ import time
 import signal
 import argparse
 from tools.teletyped import ssh_key
-from tools.teletyped.helper import log, get_dongle_id, get_api_token, API_URL, POLL_INTERVAL, KEY_PATH_PRIV, REMOTE_USER, REMOTE_HOST, REMOTE_PORT, LOCAL_PORT, PIDFILE
+from tools.teletyped.helper import (
+  log,
+  get_dongle_id,
+  get_api_token,
+  API_URL,
+  POLL_INTERVAL,
+  KEY_PATH_PRIV,
+  REMOTE_USER,
+  REMOTE_HOST,
+  REMOTE_PORT,
+  LOCAL_PORT,
+  PIDFILE,
+  has_internet_connection,
+)
 
 VERBOSE = False
 
@@ -161,6 +174,9 @@ def main():
   if not device_id:
     return
 
+  while _running and not has_internet_connection():
+    log("Waiting for internet connection...", "WARN")
+    time.sleep(60)
 
   # Check if goranconnect will respond
   check_server(API_URL)  # 👈 This blocks until server is ready
@@ -172,6 +188,10 @@ def main():
 
   while _running:
     now = time.monotonic()
+
+    if not has_internet_connection():
+      time.sleep(60)
+      continue
 
 
     if now - last_ssh_time >= POLL_INTERVAL:


### PR DESCRIPTION
## Summary
- check network connection using `HARDWARE.get_network_type`
- skip teletyped route sending and SSH setup when offline
- warn and exit early in announce_boot_routes if offline
- slow down internet wait loops to 60 seconds

## Testing
- `pre-commit run --files tools/teletyped/teletyped.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685768a141048322a2a8fe0d17ceed24