### PR TITLE
Improve teletyped compatibility

### DIFF
--- a/tools/teletyped/helper.py
+++ b/tools/teletyped/helper.py
@@ -6,20 +6,26 @@ try:
   # Newer style (e.g. `python -m openpilot.tools.teletyped.helper`)
   from openpilot.common.params import Params
   from openpilot.system.hardware import PC, HARDWARE
-  from cereal import log
 except ModuleNotFoundError:
   # Fallback for old-style in-tree execution
   from common.params import Params
   from system.hardware import PC, HARDWARE
-  from cereal import log
+
+from cereal import log
 
 
 API_URL = "https://goranconnect.duckdns.org"
 POLL_INTERVAL = 10
 CHECK_INTERVAL = 60
-KEY_PATH = "/persist/comma/id_ed25519_goranconnect.pub"
-KEY_PATH_PRIV = "/persist/comma/id_ed25519_goranconnect"
-REALDATA_DIR = "/data/media/0/realdata"
+from common.basedir import PERSIST
+
+KEY_PATH = os.path.join(PERSIST, "comma", "id_ed25519_goranconnect.pub")
+KEY_PATH_PRIV = os.path.join(PERSIST, "comma", "id_ed25519_goranconnect")
+
+if os.path.isdir("/data/media/0/realdata"):
+  REALDATA_DIR = "/data/media/0/realdata"
+else:
+  REALDATA_DIR = os.path.join(str(Path.home()), ".comma", "media", "0", "realdata")
 BOOT_DIR = os.path.join(REALDATA_DIR, "boot")
 REMOTE_USER = "ubuntu"
 REMOTE_HOST = "goranconnect.duckdns.org"

--- a/tools/teletyped/setup_resolv.sh
+++ b/tools/teletyped/setup_resolv.sh
@@ -4,7 +4,7 @@
 set -e
 echo "✅ Running in bash $BASH_VERSION"
 
-TELETYPED_DIR="/data/openpilot/tools/teletyped"
+TELETYPED_DIR="$(dirname "$(readlink -f "$0")")"
 RESOLV_SRC="$TELETYPED_DIR/resolv.conf"
 RESOLV_DEST="/etc/resolv.conf"
 
@@ -17,13 +17,17 @@ else
 fi
 
 # Remount /system writable temporarily
-mount -o rw,remount /system
+if [ -d /system ]; then
+  mount -o rw,remount /system
+fi
 
 # Ensure resolv.conf exists
 echo "[+] Ensuring /etc/resolv.conf exists"
 touch "$RESOLV_DEST"
 
-mount -o ro,remount /system
+if [ -d /system ]; then
+  mount -o ro,remount /system
+fi
 
 # Only bind-mount if it's not already bound to the source
 CURRENT_MOUNT=$(mount | grep "on $RESOLV_DEST type" | awk '{print $1}')


### PR DESCRIPTION
## Summary
- reference openpilot's persistent paths for teletyped helper constants
- handle real data path fallback on PC
- use script-relative path in `setup_resolv.sh`
- only remount /system when present
- refine helper imports to load cereal once

## Testing
- `python3 -m py_compile tools/teletyped/*.py`
- `pre-commit run --files tools/teletyped/helper.py tools/teletyped/setup_resolv.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857743de3a08322b0000b6a4453b76a