### PR TITLE
Fix lint issues in teletyped tools

### DIFF
--- a/tools/teletyped/announce_boot_routes.py
+++ b/tools/teletyped/announce_boot_routes.py
@@ -1,5 +1,4 @@
 import os
-import json
 import requests
 from datetime import datetime
 import re

--- a/tools/teletyped/helper.py
+++ b/tools/teletyped/helper.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from typing import Optional, cast
 import os
 
 try:
@@ -62,7 +63,7 @@ def get_dongle_id() -> str:
   Defaults to 'UNKNOWN_DEVICE' if not found.
   """
   params = Params()
-  dongle_id = params.get("DongleId", encoding='utf8')
+  dongle_id: Optional[str] = cast(Optional[str], params.get("DongleId", encoding='utf8'))
 
   if dongle_id is None:
     fallback_path = Path(Paths.persist_root()) / "comma" / "dongle_id"
@@ -76,8 +77,8 @@ def get_api_token() -> str:
   """
   Returns the API token from params, or an empty string if not set.
   """
-  token = Params().get("GoranConnectPassword")
-  return token.decode("utf-8") if token else ""
+  token_bytes: Optional[bytes] = cast(Optional[bytes], Params().get("GoranConnectPassword"))
+  return token_bytes.decode("utf-8") if token_bytes else ""
 
 def log(msg, level="INFO"):
-    print(f"[{datetime.now().isoformat()}] [{level}] {msg}")
+  print(f"[{datetime.now().isoformat()}] [{level}] {msg}")

--- a/tools/teletyped/route_sender.py
+++ b/tools/teletyped/route_sender.py
@@ -2,7 +2,7 @@
 import os
 import time
 import json
-from zipfile import ZipFile, ZIP_DEFLATED, ZipInfo
+from zipfile import ZipFile, ZIP_DEFLATED
 import subprocess
 import requests
 from datetime import datetime

--- a/tools/teletyped/ssh_key.py
+++ b/tools/teletyped/ssh_key.py
@@ -33,7 +33,7 @@ def generate_ssh_key():
     ], check=True)
     log("SSH key generated successfully.")
   except subprocess.CalledProcessError as e:
-    raise RuntimeError(f"Failed to generate SSH key: {e}")
+    raise RuntimeError(f"Failed to generate SSH key: {e}") from e
 
 def ensure_ssh_key():
   if not os.path.exists(KEY_PATH) or not os.path.exists(KEY_PATH_PRIV):


### PR DESCRIPTION
## Summary
- fix unused imports in teletyped tools
- fix raise without `from` in ssh_key
- satisfy mypy return type checks and indentation in helper

## Testing
- `pytest` *(fails: pyenv version not installed)*
- `pre-commit run --files tools/teletyped/announce_boot_routes.py tools/teletyped/helper.py tools/teletyped/route_sender.py tools/teletyped/ssh_key.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857781aab80832284444e802a3bb55a