### PR TITLE
Fix teletyped helper lint issues

### DIFF
--- a/tools/teletyped/helper.py
+++ b/tools/teletyped/helper.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
   from common.params import Params
   from system.hardware import PC, HARDWARE
 
-from cereal import log
+from cereal import log as cereal_log
 
 
 API_URL = "https://goranconnect.duckdns.org"
@@ -36,12 +36,12 @@ PIDFILE = "/tmp/reverse_ssh_tunnel.pid"
 WORMHOLE_BINARY = os.path.join(os.path.dirname(__file__), "wormhole-william")
 SENDER_LOG = os.path.join(os.path.dirname(__file__), "sender_log.json")
 
-NetworkType = log.DeviceState.NetworkType
+NetworkType = cereal_log.DeviceState.NetworkType
 
 def has_internet_connection() -> bool:
   """Check if the device currently has any network connectivity."""
   try:
-    return HARDWARE.get_network_type() != NetworkType.none
+    return bool(HARDWARE.get_network_type() != NetworkType.none)
   except Exception:
     return True
 


### PR DESCRIPTION
## Summary
- avoid name conflict with cereal.log
- return bool for `has_internet_connection`

## Testing
- `pre-commit` *(fails: command not found)*
- `mypy tools/teletyped/helper.py` *(fails: command not found)*
- `flake8 tools/teletyped/helper.py` *(fails: command not found)*
- `pylint tools/teletyped/helper.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685862f441cc8322ad153a35e6134e58